### PR TITLE
lab-erick

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,21 @@
+{
+  "rules": {
+    "no-console": "off",
+    "indent": [ "error", 2 ],
+    "quotes": [ "error", "single" ],
+    "semi": ["error", "always"],
+    "linebreak-style": [ "error", "unix" ]
+  },
+  "env": {
+    "es6": true,
+    "node": true,
+    "mocha": true,
+    "jasmine": true
+  },
+  "ecmaFeatures": {
+    "modules": true,
+    "experimentalObjectRestSpread": true,
+    "impliedStrict": true
+  },
+  "extends": "eslint:recommended"
+}

--- a/index.js
+++ b/index.js
@@ -3,4 +3,3 @@
 const greet = require('./lib/greet.js');
 
 greet.greet(process.argv[2]);
-console.log(process.argv[2]);

--- a/index.js
+++ b/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const greet = require('./lib/greet.js');
+
+greet.greet(process.argv[2]);
+console.log(process.argv[2]);

--- a/lib/greet.js
+++ b/lib/greet.js
@@ -5,6 +5,7 @@ var name = process.argv[2];
 
 exports.greet = function(name) {
   if (arguments.length === 0) throw new Error('name not entered');
+  console.log(`hello ${name}!`);
   return `hello ${name}!`;
 };
 

--- a/lib/greet.js
+++ b/lib/greet.js
@@ -2,7 +2,7 @@
 
 module.exports = exports = {};
 
-exports.sayHello = function(name) {
+exports.greet = function(name) {
   if (arguments.length === 0) throw new Error('name not entered');
   return `hello ${name}!`;
 };

--- a/lib/greet.js
+++ b/lib/greet.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = exports = {};
+
+exports.sayHello = function(name) {
+  if (arguments.length === 0) throw new Error('name not entered');
+  return `hello ${name}!`;
+};

--- a/lib/greet.js
+++ b/lib/greet.js
@@ -1,8 +1,12 @@
 'use strict';
 
 module.exports = exports = {};
+var name = process.argv[2];
 
 exports.greet = function(name) {
   if (arguments.length === 0) throw new Error('name not entered');
+  console.log(`hello ${name}!`);
   return `hello ${name}!`;
 };
+
+exports.greet(name);

--- a/lib/greet.js
+++ b/lib/greet.js
@@ -5,7 +5,6 @@ var name = process.argv[2];
 
 exports.greet = function(name) {
   if (arguments.length === 0) throw new Error('name not entered');
-  console.log(`hello ${name}!`);
   return `hello ${name}!`;
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const greet = require('./lib/greet.js');
+
+greet.sayHello('erick');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,0 @@
-'use strict';
-
-const greet = require('./lib/greet.js');
-
-greet.greet('erick');

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,4 +2,4 @@
 
 const greet = require('./lib/greet.js');
 
-greet.sayHello('erick');
+greet.greet('erick');

--- a/test/greet-test.js
+++ b/test/greet-test.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 describe('Greet Test Module', function () {
   describe('#greet', function () {
     //pointing back to run sayHello function
-    it('should return hello erick!', function () {
+    it(`should return hello ${process.argv[2]}!`, function () {
       var result = greet.greet(process.argv[2]);
       //creating variable that stores value of sayHello
       assert.ok(result === `hello ${process.argv[2]}!`, `not equal to hello ${result}!`);

--- a/test/greet-test.js
+++ b/test/greet-test.js
@@ -4,15 +4,17 @@ const greet = require('../lib/greet.js');
 const assert = require('assert');
 
 describe('Greet Module', function () {
-  describe('#sayHello', function () {
-    //pointing back to sayHello function
+  describe('#greet', function () {
+    //pointing back to run sayHello function
     it('should return hello erick!', function () {
-      var result = greet.sayHello('erick');
+      var result = greet.greet('erick');
+      //creating variable that stores value of sayHello
       assert.ok(result === 'hello erick!', 'not equal to hello erick!');
+      //using ok method to display result status
     });
-    it('should throw a missing name error', function () {
+    it('should throw error that name is missing', function () {
       assert.throws(function() {
-        greet.sayHello();
+        greet.greet();
       }, 'error not thrown');
     });
   });

--- a/test/greet-test.js
+++ b/test/greet-test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const greet = require('../lib/greet.js');
+const assert = require('assert');
+
+describe('Greet Module', function () {
+  describe('#sayHello', function () {
+    //pointing back to sayHello function
+    it('should return hello erick!', function () {
+      var result = greet.sayHello('erick');
+      assert.ok(result === 'hello erick!', 'not equal to hello erick!');
+    });
+    it('should throw a missing name error', function () {
+      assert.throws(function() {
+        greet.sayHello();
+      }, 'error not thrown');
+    });
+  });
+});

--- a/test/greet-test.js
+++ b/test/greet-test.js
@@ -3,19 +3,19 @@
 const greet = require('../lib/greet.js');
 const assert = require('assert');
 
-describe('Greet Module', function () {
+describe('Greet Test Module', function () {
   describe('#greet', function () {
     //pointing back to run sayHello function
     it('should return hello erick!', function () {
-      var result = greet.greet('erick');
+      var result = greet.greet(process.argv[2]);
       //creating variable that stores value of sayHello
-      assert.ok(result === 'hello erick!', 'not equal to hello erick!');
+      assert.ok(result === `hello ${process.argv[2]}!`, `not equal to hello ${result}!`);
       //using ok method to display result status
     });
     it('should throw error that name is missing', function () {
       assert.throws(function() {
         greet.greet();
-      }, 'error not thrown');
+      }, 'no error thrown');
     });
   });
 });

--- a/test/greet-test.js
+++ b/test/greet-test.js
@@ -5,10 +5,10 @@ const assert = require('assert');
 
 describe('Greet Test Module', function () {
   describe('#greet', function () {
-    //pointing back to run sayHello function
+    //pointing back to run greet function
     it(`should return hello ${process.argv[2]}!`, function () {
       var result = greet.greet(process.argv[2]);
-      //creating variable that stores value of sayHello
+      //creating variable that stores value of greet
       assert.ok(result === `hello ${process.argv[2]}!`, `not equal to hello ${result}!`);
       //using ok method to display result status
     });


### PR DESCRIPTION
Is there a way to pass in a command line utility argument when running a test in mocha? I used the process.argv[2] as the command line utility argument and it works when running node greet.js 'name'. However, since it is initially undefined, I get 'hello undefined!' when I run my test. I would just like to see it run the test with a name.

In class, Brian mentioned that running a return would stop any code after the return from running. I originally used a console.log and return of the hello string. But when I first set it up, I placed the console.log after the return statement and received an error stating "unreachable code". It was good to see that error and really think about it.